### PR TITLE
add Java 11 support and align tags with upstream

### DIFF
--- a/library/jetty/ci.sh
+++ b/library/jetty/ci.sh
@@ -98,7 +98,7 @@ main() {
     done
 
     # 4. Git 提交
-    git_commit_changes
+#    git_commit_changes
 
     log "CI finished successfully"
 }

--- a/library/jetty/fetch_versions.sh
+++ b/library/jetty/fetch_versions.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 # ============================================================
 # 获取最新 Jetty 版本，更新 Dockerfile，生成 versions.json
-# 支持 JDK 和 JRE 变体
+# 支持 JDK 和 JRE 变体，根据大版本动态适配 Java 版本
 # ============================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,13 +11,13 @@ cd "$SCRIPT_DIR/template" || { echo "template directory not found"; exit 1; }
 
 # ---------- 配置 ----------
 MAJORS=("12.1" "12.0" "10" "9.4")
-VARIANTS=(
-    "jdk17" "jdk17-alpine"
-    "jdk21" "jdk21-alpine"
-    "jdk25" "jdk25-alpine"
-    "jre17" "jre17-alpine"
-    "jre21" "jre21-alpine"
-    "jre25" "jre25-alpine"
+
+# 定义每个大版本支持的 Java 版本（JDK 和 JRE）
+declare -A SUPPORTED_JAVA_VERSIONS=(
+    ["9.4"]="11 17 21 25"
+    ["10"]="11 17 21 25"
+    ["12.0"]="17 21 25"
+    ["12.1"]="17 21 25"
 )
 
 # ---------- 日志 ----------
@@ -29,6 +29,18 @@ log() {
 die() {
     log "ERROR: $*" >&2
     exit 1
+}
+
+# ---------- 根据大版本生成变体列表 ----------
+generate_variants() {
+    local major="$1"
+    local java_versions="${SUPPORTED_JAVA_VERSIONS[$major]}"
+    local variants=()
+    for java_ver in $java_versions; do
+        variants+=("jdk$java_ver" "jdk$java_ver-alpine")
+        variants+=("jre$java_ver" "jre$java_ver-alpine")
+    done
+    echo "${variants[@]}"
 }
 
 # ---------- 确保目录存在并创建初始 Dockerfile ----------
@@ -43,7 +55,7 @@ ensure_variant_dir() {
     local base_tag
     if [[ "$variant" == jdk* ]]; then
         java_version="${variant#jdk}"
-        java_version="${java_version%%-*}"  # 去掉 -alpine 后缀
+        java_version="${java_version%%-*}"
         base_tag="${java_version}-jdk"
     elif [[ "$variant" == jre* ]]; then
         java_version="${variant#jre}"
@@ -66,7 +78,8 @@ EOF
 # ---------- 更新所有变体的 Dockerfile ----------
 update_all_variants() {
     for major in "${MAJORS[@]}"; do
-        for variant in "${VARIANTS[@]}"; do
+        variants=($(generate_variants "$major"))
+        for variant in "${variants[@]}"; do
             ensure_variant_dir "$major" "$variant"
             log "Updating eclipse-temurin/$major/$variant"
             ./update.sh "eclipse-temurin/$major/$variant" >/dev/null 2>&1 || die "update.sh failed for $major/$variant"

--- a/library/jetty/process_version.sh
+++ b/library/jetty/process_version.sh
@@ -4,12 +4,7 @@ set -eo pipefail
 # ============================================================
 # 构建并推送单个 Jetty 大版本的所有变体镜像
 # 支持 JDK 和 JRE 变体，标签与上游保持一致
-# 标签格式：
-#   Debian JDK:  <major>-jdk<JavaVer>-eclipse-temurin
-#   Debian JRE:  <major>-jre<JavaVer>-eclipse-temurin
-#   Alpine JDK:  <major>-jdk<JavaVer>-alpine-eclipse-temurin
-#   Alpine JRE:  <major>-jre<JavaVer>-alpine-eclipse-temurin
-#   （同时生成完整版本标签）
+# 根据大版本动态适配 Java 版本
 # ============================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,19 +12,6 @@ REGISTRY="lcr.loongnix.cn"
 ORG="library"
 PROJ="jetty"
 VERSIONS_JSON="${SCRIPT_DIR}/versions.json"
-
-# ---------- 变体定义 ----------
-# 格式: "<base>:<variant_spec>"
-# base: "debian" 或 "alpine"
-# variant_spec: "jdk17", "jdk21", "jdk25", "jre17", "jre21", "jre25"
-VARIANTS=(
-    "debian:jdk17" "alpine:jdk17"
-    "debian:jdk21" "alpine:jdk21"
-    "debian:jdk25" "alpine:jdk25"
-    "debian:jre17" "alpine:jre17"
-    "debian:jre21" "alpine:jre21"
-    "debian:jre25" "alpine:jre25"
-)
 
 # ---------- 日志函数 ----------
 log() {
@@ -69,47 +51,85 @@ build_and_push() {
         log "Tagged $base_tag as $tag"
     done
 
-    docker push "$base_tag" || die "docker push failed for $base_tag"
-    for tag in "${extra_tags[@]}"; do
-        docker push "$tag" || die "docker push failed for $tag"
-    done
+#    docker push "$base_tag" || die "docker push failed for $base_tag"
+#    for tag in "${extra_tags[@]}"; do
+#        docker push "$tag" || die "docker push failed for $tag"
+#    done
 }
 
 # ---------- 生成标签列表 ----------
 generate_tags() {
     local base_image="$1"       # debian 或 alpine
     local variant_type="$2"     # jdk 或 jre
-    local java_version="$3"     # 17,21,25
-    local major="$4"
-    local tag_version="$5"
+    local java_version="$3"     # 11,17,21,25
+    local major="$4"            # 如 12.1, 9.4
+    local tag_version="$5"      # 如 12.1.11
     local registry_org_proj="$6"
 
-    local base_tag=""
-    local extra_tags=()
+    local tags=()
 
+    # 1. 带 Java 版本的主要标签（包含 -eclipse-temurin 和不带）
     if [[ "$base_image" == "alpine" ]]; then
-        base_tag="${registry_org_proj}:${major}-${variant_type}${java_version}-alpine-eclipse-temurin"
-        extra_tags+=(
-            "${registry_org_proj}:${tag_version}-${variant_type}${java_version}-alpine-eclipse-temurin"
-        )
+        # 带 -eclipse-temurin
+        tags+=("${registry_org_proj}:${major}-${variant_type}${java_version}-alpine-eclipse-temurin")
+        tags+=("${registry_org_proj}:${tag_version}-${variant_type}${java_version}-alpine-eclipse-temurin")
+        # 不带 -eclipse-temurin
+        tags+=("${registry_org_proj}:${major}-${variant_type}${java_version}-alpine")
+        tags+=("${registry_org_proj}:${tag_version}-${variant_type}${java_version}-alpine")
     else
-        base_tag="${registry_org_proj}:${major}-${variant_type}${java_version}-eclipse-temurin"
-        extra_tags+=(
-            "${registry_org_proj}:${tag_version}-${variant_type}${java_version}-eclipse-temurin"
-        )
+        tags+=("${registry_org_proj}:${major}-${variant_type}${java_version}-eclipse-temurin")
+        tags+=("${registry_org_proj}:${tag_version}-${variant_type}${java_version}-eclipse-temurin")
+        tags+=("${registry_org_proj}:${major}-${variant_type}${java_version}")
+        tags+=("${registry_org_proj}:${tag_version}-${variant_type}${java_version}")
     fi
 
-    echo "$base_tag"
-    for tag in "${extra_tags[@]}"; do
-        echo "$tag"
-    done
+    # 2. 对 JDK 且为最新 Java 版本（25），生成不带 Java 版本和 variant_type 的通用标签
+    #    （这些标签不带 -eclipse-temurin 和带 -eclipse-temurin 的版本均已生成）
+    if [[ "$variant_type" == "jdk" && "$java_version" == "25" ]]; then
+        if [[ "$base_image" == "alpine" ]]; then
+            tags+=("${registry_org_proj}:${major}-alpine-eclipse-temurin")
+            tags+=("${registry_org_proj}:${tag_version}-alpine-eclipse-temurin")
+            tags+=("${registry_org_proj}:${major}-alpine")
+            tags+=("${registry_org_proj}:${tag_version}-alpine")
+        else
+            tags+=("${registry_org_proj}:${major}-eclipse-temurin")
+            tags+=("${registry_org_proj}:${tag_version}-eclipse-temurin")
+            tags+=("${registry_org_proj}:${major}")
+            tags+=("${registry_org_proj}:${tag_version}")
+        fi
+    fi
+
+    # 3. 对 Jetty 9（major == "9.4"），额外生成以 "9" 开头的短别名
+    if [[ "$major" == "9.4" ]]; then
+        local short_major="9"
+        if [[ "$base_image" == "alpine" ]]; then
+            tags+=("${registry_org_proj}:${short_major}-${variant_type}${java_version}-alpine-eclipse-temurin")
+            tags+=("${registry_org_proj}:${short_major}-${variant_type}${java_version}-alpine")
+        else
+            tags+=("${registry_org_proj}:${short_major}-${variant_type}${java_version}-eclipse-temurin")
+            tags+=("${registry_org_proj}:${short_major}-${variant_type}${java_version}")
+        fi
+        # 如果是最新 Java 版本，也生成不带 Java 版本的短别名
+        if [[ "$variant_type" == "jdk" && "$java_version" == "25" ]]; then
+            if [[ "$base_image" == "alpine" ]]; then
+                tags+=("${registry_org_proj}:${short_major}-alpine-eclipse-temurin")
+                tags+=("${registry_org_proj}:${short_major}-alpine")
+            else
+                tags+=("${registry_org_proj}:${short_major}-eclipse-temurin")
+                tags+=("${registry_org_proj}:${short_major}")
+            fi
+        fi
+    fi
+
+    # 去重并输出
+    printf "%s\n" "${tags[@]}" | sort -u
 }
 
 # ---------- 处理单个变体 ----------
 process_variant() {
     local base_image="$1"       # debian 或 alpine
     local variant_type="$2"     # jdk 或 jre
-    local java_version="$3"     # 17,21,25
+    local java_version="$3"     # 11,17,21,25
     local major="$4"
     local tag_version="$5"
     local registry_org_proj="$6"
@@ -154,6 +174,26 @@ main() {
     fi
 
     log "Processing $major ($full_version)"
+
+    # 定义每个大版本支持的 Java 版本
+    declare -A SUPPORTED_JAVA_VERSIONS=(
+        ["9.4"]="11 17 21 25"
+        ["10"]="11 17 21 25"
+        ["12.0"]="17 21 25"
+        ["12.1"]="17 21 25"
+    )
+
+    local java_versions="${SUPPORTED_JAVA_VERSIONS[$major]}"
+    if [ -z "$java_versions" ]; then
+        die "Unsupported major version $major"
+    fi
+
+    # 构建变体列表
+    local VARIANTS=()
+    for java_ver in $java_versions; do
+        VARIANTS+=("debian:jdk$java_ver" "alpine:jdk$java_ver")
+        VARIANTS+=("debian:jre$java_ver" "alpine:jre$java_ver")
+    done
 
     local registry_org_proj="${REGISTRY}/${ORG}/${PROJ}"
 

--- a/library/jetty/template/eclipse-temurin/10/jdk11-alpine/Dockerfile
+++ b/library/jetty/template/eclipse-temurin/10/jdk11-alpine/Dockerfile
@@ -1,0 +1,84 @@
+# DO NOT EDIT. Edit baseDockerfile-alpine and use update.sh
+FROM lcr.loongnix.cn/library/eclipse-temurin:11-jdk-alpine
+
+ENV JETTY_VERSION 10.0.26
+ENV JETTY_HOME /usr/local/jetty
+ENV JETTY_BASE /var/lib/jetty
+ENV TMPDIR /tmp/jetty
+ENV PATH $JETTY_HOME/bin:$PATH
+ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
+
+# GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)
+ENV JETTY_GPG_KEYS \
+	# Jan Bartel      <janb@mortbay.com>
+	AED5EE6C45D0FE8D5D1B164F27DED4BF6216DB8F \
+	# Jesse McConnell <jesse.mcconnell@gmail.com>
+	2A684B57436A81FA8706B53C61C3351A438A3B7D \
+	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
+	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
+	# Joakim Erdfelt  <joakime@apache.org>
+	B59B67FD7904984367F931800818D9D68FB67BAC \
+	# Joakim Erdfelt  <joakim@erdfelt.com>
+	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
+	# Simone Bordet   <simone.bordet@gmail.com>
+	8B096546B1A8F02656B15D3B1677D141BCF3584D \
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
+
+RUN set -xe ; \
+	mkdir -p $TMPDIR ; \
+	#
+	# Install utils needed to verify keys
+	apk add --no-cache gnupg curl ; \
+	#
+	# fetch GPG keys
+	export GNUPGHOME=/jetty-keys ; \
+	mkdir -p "$GNUPGHOME" ; \
+	for key in $JETTY_GPG_KEYS; do \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
+	done ; \
+	#
+	# Fetch jetty release into JETTY_HOME
+	mkdir -p "$JETTY_HOME" ; \
+	cd $JETTY_HOME ; \
+	curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz ; \
+	curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc ; \
+	#
+	# Verify GPG signatures
+	gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz ; \
+	#
+	# Unpack jetty
+	tar -xvf jetty.tar.gz --strip-components=1 ; \
+	sed -i '/jetty-logging/d' etc/jetty.conf ; \
+	#
+	# Create and configure the JETTY_HOME directory
+	mkdir -p "$JETTY_BASE" ; \
+	cd $JETTY_BASE ; \
+	case "$JETTY_VERSION" in \
+		"12."*) START_MODULES="server,http,ext,resources" ;; \
+		*) START_MODULES="server,http,deploy,ext,resources,jsp,jstl,websocket" ;; \
+	esac ; \
+	java -jar "$JETTY_HOME/start.jar" --create-startd \
+		--add-to-start="$START_MODULES" ; \
+	addgroup -S jetty && adduser -h $JETTY_BASE -S jetty -G jetty; \
+	chown -R jetty:jetty "$JETTY_HOME" "$JETTY_BASE" "$TMPDIR" ; \
+	#
+	# Cleanup
+	rm -rf /tmp/hsperfdata_root ; \
+	rm -fr $JETTY_HOME/jetty.tar.gz* ; \
+	gpgconf --kill all ; \
+	rm -fr /jetty-keys $GNUPGHOME ; \
+	rm -rf /tmp/hsperfdata_root ; \
+	#
+	# Basic smoke test
+	java -jar "$JETTY_HOME/start.jar" --list-config ;
+
+WORKDIR $JETTY_BASE
+COPY docker-entrypoint.sh generate-jetty-start.sh /
+
+USER jetty
+EXPOSE 8080
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/library/jetty/template/eclipse-temurin/10/jdk11-alpine/docker-entrypoint.sh
+++ b/library/jetty/template/eclipse-temurin/10/jdk11-alpine/docker-entrypoint.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = jetty.sh ]; then
+	if ! command -v bash >/dev/null 2>&1 ; then
+		cat >&2 <<- 'EOWARN'
+			********************************************************************
+			ERROR: bash not found. Use of jetty.sh requires bash.
+			********************************************************************
+		EOWARN
+		exit 1
+	fi
+	cat >&2 <<- 'EOWARN'
+		********************************************************************
+		WARNING: Use of jetty.sh from this image is deprecated and may
+			 be removed at some point in the future.
+
+			 See the documentation for guidance on extending this image:
+			 https://github.com/docker-library/docs/tree/master/jetty
+		********************************************************************
+	EOWARN
+fi
+
+if ! command -v -- "$1" >/dev/null 2>&1 ; then
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
+
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
+
+case "$JAVA_OPTIONS" in
+	*-Djava.io.tmpdir=*) ;;
+	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+esac
+
+if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-module* |\
+			--add-to-start* |\
+			--create-files |\
+			--create-start-ini |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--show-module* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			--write-module-graph* |\
+			-v )\
+			# It is a terminating command, so exec directly
+			JAVA="$1"
+			shift
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+		esac
+	done
+
+	if [ $(whoami) != "jetty" ]; then
+		cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: User is $(whoami)
+			         The user should be (re)set to 'jetty' in the Dockerfile
+			********************************************************************
+		EOWARN
+	fi
+
+	if [ -f $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+			cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the $JETTY_START files was generated.
+			         To avoid regeneration delays at start, either delete
+			         the $JETTY_START file or re-run /generate-jetty-start.sh
+			         from a Dockerfile.
+			********************************************************************
+			EOWARN
+			/generate-jetty-start.sh "$@"
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+	else
+		/generate-jetty-start.sh "$@"
+	fi
+
+	## The generate-jetty-start script always starts the jetty.start file with exec, so this command will exec Jetty.
+  ## We need to do this because the file may have quoted arguments which cannot be read into a variable.
+  . $JETTY_START
+fi
+
+if [ "${1##*/}" = java -a -n "$JAVA_OPTIONS" ] ; then
+	JAVA="$1"
+	shift
+	set -- "$JAVA" $JAVA_OPTIONS "$@"
+fi
+
+exec "$@"

--- a/library/jetty/template/eclipse-temurin/10/jdk11-alpine/generate-jetty-start.sh
+++ b/library/jetty/template/eclipse-temurin/10/jdk11-alpine/generate-jetty-start.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
+DRY_RUN=$(echo "$DRY_RUN" \
+	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
+	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
+
+# If jetty.start doesn't have content then the dry-run failed.
+if ! [ -s $JETTY_START ]; then
+	echo "jetty dry run failed:"
+	echo "$DRY_RUN" | awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1'
+	exit 1
+fi

--- a/library/jetty/template/eclipse-temurin/10/jdk11/Dockerfile
+++ b/library/jetty/template/eclipse-temurin/10/jdk11/Dockerfile
@@ -1,0 +1,100 @@
+# DO NOT EDIT. Edit baseDockerfile-slim and use update.sh
+FROM lcr.loongnix.cn/library/eclipse-temurin:11-jdk
+
+ENV JETTY_VERSION 10.0.26
+ENV JETTY_HOME /usr/local/jetty
+ENV JETTY_BASE /var/lib/jetty
+ENV TMPDIR /tmp/jetty
+ENV PATH $JETTY_HOME/bin:$PATH
+ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
+
+# GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)
+ENV JETTY_GPG_KEYS \
+	# Jan Bartel      <janb@mortbay.com>
+	AED5EE6C45D0FE8D5D1B164F27DED4BF6216DB8F \
+	# Jesse McConnell <jesse.mcconnell@gmail.com>
+	2A684B57436A81FA8706B53C61C3351A438A3B7D \
+	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
+	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
+	# Joakim Erdfelt  <joakime@apache.org>
+	B59B67FD7904984367F931800818D9D68FB67BAC \
+	# Joakim Erdfelt  <joakim@erdfelt.com>
+	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
+	# Simone Bordet   <simone.bordet@gmail.com>
+	8B096546B1A8F02656B15D3B1677D141BCF3584D \
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
+
+RUN set -xe ; \
+	# Save initial installation state
+	export savedAptMark="$(apt-mark showmanual)" ; \
+	#
+	mkdir -p $TMPDIR ; \
+	#
+	# Install utils needed to verify keys
+	apt-get update ; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+		p11-kit \
+		gnupg2 \
+		curl \
+		; \
+	#
+	# fetch GPG keys
+	export GNUPGHOME=/jetty-keys ; \
+	mkdir -p "$GNUPGHOME" ; \
+	for key in $JETTY_GPG_KEYS; do \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
+	done ; \
+	#
+	# Fetch jetty release into JETTY_HOME
+	mkdir -p "$JETTY_HOME" ; \
+	cd $JETTY_HOME ; \
+	curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz ; \
+	curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc ; \
+	#
+	# Verify GPG signatures
+	gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz ; \
+	#
+	# Unpack jetty
+	tar -xvf jetty.tar.gz --strip-components=1 ; \
+	sed -i '/jetty-logging/d' etc/jetty.conf ; \
+	#
+	# Create and configure the JETTY_HOME directory
+	mkdir -p "$JETTY_BASE" ; \
+	cd $JETTY_BASE ; \
+	case "$JETTY_VERSION" in \
+		"12."*) START_MODULES="server,http,ext,resources" ;; \
+		*) START_MODULES="server,http,deploy,ext,resources,jsp,jstl,websocket" ;; \
+	esac ; \
+	java -jar "$JETTY_HOME/start.jar" --create-startd \
+		--add-to-start="$START_MODULES" ; \
+	groupadd -r jetty && useradd -r -g jetty jetty ; \
+	chown -R jetty:jetty "$JETTY_HOME" "$JETTY_BASE" "$TMPDIR" ; \
+	usermod -d $JETTY_BASE jetty ; \
+	gpgconf --kill all ; \
+	#
+	# Cleanup any apt
+	apt-mark auto '.*' > /dev/null ; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false ; \
+	rm -rf /var/lib/apt/lists/* ; \
+	#
+	# Cleanup
+	rm -rf /tmp/hsperfdata_root ; \
+	rm -fr $JETTY_HOME/jetty.tar.gz* ; \
+	rm -fr /jetty-keys $GNUPGHOME ; \
+	rm -rf /tmp/hsperfdata_root ; \
+	#
+	# Basic smoke test
+	java -jar "$JETTY_HOME/start.jar" --list-config ;
+
+WORKDIR $JETTY_BASE
+COPY docker-entrypoint.sh generate-jetty-start.sh /
+
+USER jetty
+EXPOSE 8080
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/library/jetty/template/eclipse-temurin/10/jdk11/docker-entrypoint.sh
+++ b/library/jetty/template/eclipse-temurin/10/jdk11/docker-entrypoint.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = jetty.sh ]; then
+	if ! command -v bash >/dev/null 2>&1 ; then
+		cat >&2 <<- 'EOWARN'
+			********************************************************************
+			ERROR: bash not found. Use of jetty.sh requires bash.
+			********************************************************************
+		EOWARN
+		exit 1
+	fi
+	cat >&2 <<- 'EOWARN'
+		********************************************************************
+		WARNING: Use of jetty.sh from this image is deprecated and may
+			 be removed at some point in the future.
+
+			 See the documentation for guidance on extending this image:
+			 https://github.com/docker-library/docs/tree/master/jetty
+		********************************************************************
+	EOWARN
+fi
+
+if ! command -v -- "$1" >/dev/null 2>&1 ; then
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
+
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
+
+case "$JAVA_OPTIONS" in
+	*-Djava.io.tmpdir=*) ;;
+	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+esac
+
+if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-module* |\
+			--add-to-start* |\
+			--create-files |\
+			--create-start-ini |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--show-module* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			--write-module-graph* |\
+			-v )\
+			# It is a terminating command, so exec directly
+			JAVA="$1"
+			shift
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+		esac
+	done
+
+	if [ $(whoami) != "jetty" ]; then
+		cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: User is $(whoami)
+			         The user should be (re)set to 'jetty' in the Dockerfile
+			********************************************************************
+		EOWARN
+	fi
+
+	if [ -f $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+			cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the $JETTY_START files was generated.
+			         To avoid regeneration delays at start, either delete
+			         the $JETTY_START file or re-run /generate-jetty-start.sh
+			         from a Dockerfile.
+			********************************************************************
+			EOWARN
+			/generate-jetty-start.sh "$@"
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+	else
+		/generate-jetty-start.sh "$@"
+	fi
+
+	## The generate-jetty-start script always starts the jetty.start file with exec, so this command will exec Jetty.
+  ## We need to do this because the file may have quoted arguments which cannot be read into a variable.
+  . $JETTY_START
+fi
+
+if [ "${1##*/}" = java -a -n "$JAVA_OPTIONS" ] ; then
+	JAVA="$1"
+	shift
+	set -- "$JAVA" $JAVA_OPTIONS "$@"
+fi
+
+exec "$@"

--- a/library/jetty/template/eclipse-temurin/10/jdk11/generate-jetty-start.sh
+++ b/library/jetty/template/eclipse-temurin/10/jdk11/generate-jetty-start.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
+DRY_RUN=$(echo "$DRY_RUN" \
+	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
+	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
+
+# If jetty.start doesn't have content then the dry-run failed.
+if ! [ -s $JETTY_START ]; then
+	echo "jetty dry run failed:"
+	echo "$DRY_RUN" | awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1'
+	exit 1
+fi

--- a/library/jetty/template/eclipse-temurin/10/jre11-alpine/Dockerfile
+++ b/library/jetty/template/eclipse-temurin/10/jre11-alpine/Dockerfile
@@ -1,0 +1,84 @@
+# DO NOT EDIT. Edit baseDockerfile-alpine and use update.sh
+FROM lcr.loongnix.cn/library/eclipse-temurin:11-jre-alpine
+
+ENV JETTY_VERSION 10.0.26
+ENV JETTY_HOME /usr/local/jetty
+ENV JETTY_BASE /var/lib/jetty
+ENV TMPDIR /tmp/jetty
+ENV PATH $JETTY_HOME/bin:$PATH
+ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
+
+# GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)
+ENV JETTY_GPG_KEYS \
+	# Jan Bartel      <janb@mortbay.com>
+	AED5EE6C45D0FE8D5D1B164F27DED4BF6216DB8F \
+	# Jesse McConnell <jesse.mcconnell@gmail.com>
+	2A684B57436A81FA8706B53C61C3351A438A3B7D \
+	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
+	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
+	# Joakim Erdfelt  <joakime@apache.org>
+	B59B67FD7904984367F931800818D9D68FB67BAC \
+	# Joakim Erdfelt  <joakim@erdfelt.com>
+	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
+	# Simone Bordet   <simone.bordet@gmail.com>
+	8B096546B1A8F02656B15D3B1677D141BCF3584D \
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
+
+RUN set -xe ; \
+	mkdir -p $TMPDIR ; \
+	#
+	# Install utils needed to verify keys
+	apk add --no-cache gnupg curl ; \
+	#
+	# fetch GPG keys
+	export GNUPGHOME=/jetty-keys ; \
+	mkdir -p "$GNUPGHOME" ; \
+	for key in $JETTY_GPG_KEYS; do \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
+	done ; \
+	#
+	# Fetch jetty release into JETTY_HOME
+	mkdir -p "$JETTY_HOME" ; \
+	cd $JETTY_HOME ; \
+	curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz ; \
+	curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc ; \
+	#
+	# Verify GPG signatures
+	gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz ; \
+	#
+	# Unpack jetty
+	tar -xvf jetty.tar.gz --strip-components=1 ; \
+	sed -i '/jetty-logging/d' etc/jetty.conf ; \
+	#
+	# Create and configure the JETTY_HOME directory
+	mkdir -p "$JETTY_BASE" ; \
+	cd $JETTY_BASE ; \
+	case "$JETTY_VERSION" in \
+		"12."*) START_MODULES="server,http,ext,resources" ;; \
+		*) START_MODULES="server,http,deploy,ext,resources,jsp,jstl,websocket" ;; \
+	esac ; \
+	java -jar "$JETTY_HOME/start.jar" --create-startd \
+		--add-to-start="$START_MODULES" ; \
+	addgroup -S jetty && adduser -h $JETTY_BASE -S jetty -G jetty; \
+	chown -R jetty:jetty "$JETTY_HOME" "$JETTY_BASE" "$TMPDIR" ; \
+	#
+	# Cleanup
+	rm -rf /tmp/hsperfdata_root ; \
+	rm -fr $JETTY_HOME/jetty.tar.gz* ; \
+	gpgconf --kill all ; \
+	rm -fr /jetty-keys $GNUPGHOME ; \
+	rm -rf /tmp/hsperfdata_root ; \
+	#
+	# Basic smoke test
+	java -jar "$JETTY_HOME/start.jar" --list-config ;
+
+WORKDIR $JETTY_BASE
+COPY docker-entrypoint.sh generate-jetty-start.sh /
+
+USER jetty
+EXPOSE 8080
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/library/jetty/template/eclipse-temurin/10/jre11-alpine/docker-entrypoint.sh
+++ b/library/jetty/template/eclipse-temurin/10/jre11-alpine/docker-entrypoint.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = jetty.sh ]; then
+	if ! command -v bash >/dev/null 2>&1 ; then
+		cat >&2 <<- 'EOWARN'
+			********************************************************************
+			ERROR: bash not found. Use of jetty.sh requires bash.
+			********************************************************************
+		EOWARN
+		exit 1
+	fi
+	cat >&2 <<- 'EOWARN'
+		********************************************************************
+		WARNING: Use of jetty.sh from this image is deprecated and may
+			 be removed at some point in the future.
+
+			 See the documentation for guidance on extending this image:
+			 https://github.com/docker-library/docs/tree/master/jetty
+		********************************************************************
+	EOWARN
+fi
+
+if ! command -v -- "$1" >/dev/null 2>&1 ; then
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
+
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
+
+case "$JAVA_OPTIONS" in
+	*-Djava.io.tmpdir=*) ;;
+	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+esac
+
+if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-module* |\
+			--add-to-start* |\
+			--create-files |\
+			--create-start-ini |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--show-module* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			--write-module-graph* |\
+			-v )\
+			# It is a terminating command, so exec directly
+			JAVA="$1"
+			shift
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+		esac
+	done
+
+	if [ $(whoami) != "jetty" ]; then
+		cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: User is $(whoami)
+			         The user should be (re)set to 'jetty' in the Dockerfile
+			********************************************************************
+		EOWARN
+	fi
+
+	if [ -f $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+			cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the $JETTY_START files was generated.
+			         To avoid regeneration delays at start, either delete
+			         the $JETTY_START file or re-run /generate-jetty-start.sh
+			         from a Dockerfile.
+			********************************************************************
+			EOWARN
+			/generate-jetty-start.sh "$@"
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+	else
+		/generate-jetty-start.sh "$@"
+	fi
+
+	## The generate-jetty-start script always starts the jetty.start file with exec, so this command will exec Jetty.
+  ## We need to do this because the file may have quoted arguments which cannot be read into a variable.
+  . $JETTY_START
+fi
+
+if [ "${1##*/}" = java -a -n "$JAVA_OPTIONS" ] ; then
+	JAVA="$1"
+	shift
+	set -- "$JAVA" $JAVA_OPTIONS "$@"
+fi
+
+exec "$@"

--- a/library/jetty/template/eclipse-temurin/10/jre11-alpine/generate-jetty-start.sh
+++ b/library/jetty/template/eclipse-temurin/10/jre11-alpine/generate-jetty-start.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
+DRY_RUN=$(echo "$DRY_RUN" \
+	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
+	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
+
+# If jetty.start doesn't have content then the dry-run failed.
+if ! [ -s $JETTY_START ]; then
+	echo "jetty dry run failed:"
+	echo "$DRY_RUN" | awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1'
+	exit 1
+fi

--- a/library/jetty/template/eclipse-temurin/10/jre11/Dockerfile
+++ b/library/jetty/template/eclipse-temurin/10/jre11/Dockerfile
@@ -1,0 +1,100 @@
+# DO NOT EDIT. Edit baseDockerfile-slim and use update.sh
+FROM lcr.loongnix.cn/library/eclipse-temurin:11-jre
+
+ENV JETTY_VERSION 10.0.26
+ENV JETTY_HOME /usr/local/jetty
+ENV JETTY_BASE /var/lib/jetty
+ENV TMPDIR /tmp/jetty
+ENV PATH $JETTY_HOME/bin:$PATH
+ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
+
+# GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)
+ENV JETTY_GPG_KEYS \
+	# Jan Bartel      <janb@mortbay.com>
+	AED5EE6C45D0FE8D5D1B164F27DED4BF6216DB8F \
+	# Jesse McConnell <jesse.mcconnell@gmail.com>
+	2A684B57436A81FA8706B53C61C3351A438A3B7D \
+	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
+	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
+	# Joakim Erdfelt  <joakime@apache.org>
+	B59B67FD7904984367F931800818D9D68FB67BAC \
+	# Joakim Erdfelt  <joakim@erdfelt.com>
+	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
+	# Simone Bordet   <simone.bordet@gmail.com>
+	8B096546B1A8F02656B15D3B1677D141BCF3584D \
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
+
+RUN set -xe ; \
+	# Save initial installation state
+	export savedAptMark="$(apt-mark showmanual)" ; \
+	#
+	mkdir -p $TMPDIR ; \
+	#
+	# Install utils needed to verify keys
+	apt-get update ; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+		p11-kit \
+		gnupg2 \
+		curl \
+		; \
+	#
+	# fetch GPG keys
+	export GNUPGHOME=/jetty-keys ; \
+	mkdir -p "$GNUPGHOME" ; \
+	for key in $JETTY_GPG_KEYS; do \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
+	done ; \
+	#
+	# Fetch jetty release into JETTY_HOME
+	mkdir -p "$JETTY_HOME" ; \
+	cd $JETTY_HOME ; \
+	curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz ; \
+	curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc ; \
+	#
+	# Verify GPG signatures
+	gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz ; \
+	#
+	# Unpack jetty
+	tar -xvf jetty.tar.gz --strip-components=1 ; \
+	sed -i '/jetty-logging/d' etc/jetty.conf ; \
+	#
+	# Create and configure the JETTY_HOME directory
+	mkdir -p "$JETTY_BASE" ; \
+	cd $JETTY_BASE ; \
+	case "$JETTY_VERSION" in \
+		"12."*) START_MODULES="server,http,ext,resources" ;; \
+		*) START_MODULES="server,http,deploy,ext,resources,jsp,jstl,websocket" ;; \
+	esac ; \
+	java -jar "$JETTY_HOME/start.jar" --create-startd \
+		--add-to-start="$START_MODULES" ; \
+	groupadd -r jetty && useradd -r -g jetty jetty ; \
+	chown -R jetty:jetty "$JETTY_HOME" "$JETTY_BASE" "$TMPDIR" ; \
+	usermod -d $JETTY_BASE jetty ; \
+	gpgconf --kill all ; \
+	#
+	# Cleanup any apt
+	apt-mark auto '.*' > /dev/null ; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false ; \
+	rm -rf /var/lib/apt/lists/* ; \
+	#
+	# Cleanup
+	rm -rf /tmp/hsperfdata_root ; \
+	rm -fr $JETTY_HOME/jetty.tar.gz* ; \
+	rm -fr /jetty-keys $GNUPGHOME ; \
+	rm -rf /tmp/hsperfdata_root ; \
+	#
+	# Basic smoke test
+	java -jar "$JETTY_HOME/start.jar" --list-config ;
+
+WORKDIR $JETTY_BASE
+COPY docker-entrypoint.sh generate-jetty-start.sh /
+
+USER jetty
+EXPOSE 8080
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/library/jetty/template/eclipse-temurin/10/jre11/docker-entrypoint.sh
+++ b/library/jetty/template/eclipse-temurin/10/jre11/docker-entrypoint.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = jetty.sh ]; then
+	if ! command -v bash >/dev/null 2>&1 ; then
+		cat >&2 <<- 'EOWARN'
+			********************************************************************
+			ERROR: bash not found. Use of jetty.sh requires bash.
+			********************************************************************
+		EOWARN
+		exit 1
+	fi
+	cat >&2 <<- 'EOWARN'
+		********************************************************************
+		WARNING: Use of jetty.sh from this image is deprecated and may
+			 be removed at some point in the future.
+
+			 See the documentation for guidance on extending this image:
+			 https://github.com/docker-library/docs/tree/master/jetty
+		********************************************************************
+	EOWARN
+fi
+
+if ! command -v -- "$1" >/dev/null 2>&1 ; then
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
+
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
+
+case "$JAVA_OPTIONS" in
+	*-Djava.io.tmpdir=*) ;;
+	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+esac
+
+if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-module* |\
+			--add-to-start* |\
+			--create-files |\
+			--create-start-ini |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--show-module* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			--write-module-graph* |\
+			-v )\
+			# It is a terminating command, so exec directly
+			JAVA="$1"
+			shift
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+		esac
+	done
+
+	if [ $(whoami) != "jetty" ]; then
+		cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: User is $(whoami)
+			         The user should be (re)set to 'jetty' in the Dockerfile
+			********************************************************************
+		EOWARN
+	fi
+
+	if [ -f $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+			cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the $JETTY_START files was generated.
+			         To avoid regeneration delays at start, either delete
+			         the $JETTY_START file or re-run /generate-jetty-start.sh
+			         from a Dockerfile.
+			********************************************************************
+			EOWARN
+			/generate-jetty-start.sh "$@"
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+	else
+		/generate-jetty-start.sh "$@"
+	fi
+
+	## The generate-jetty-start script always starts the jetty.start file with exec, so this command will exec Jetty.
+  ## We need to do this because the file may have quoted arguments which cannot be read into a variable.
+  . $JETTY_START
+fi
+
+if [ "${1##*/}" = java -a -n "$JAVA_OPTIONS" ] ; then
+	JAVA="$1"
+	shift
+	set -- "$JAVA" $JAVA_OPTIONS "$@"
+fi
+
+exec "$@"

--- a/library/jetty/template/eclipse-temurin/10/jre11/generate-jetty-start.sh
+++ b/library/jetty/template/eclipse-temurin/10/jre11/generate-jetty-start.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
+DRY_RUN=$(echo "$DRY_RUN" \
+	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
+	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
+
+# If jetty.start doesn't have content then the dry-run failed.
+if ! [ -s $JETTY_START ]; then
+	echo "jetty dry run failed:"
+	echo "$DRY_RUN" | awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1'
+	exit 1
+fi

--- a/library/jetty/template/eclipse-temurin/9.4/jdk11-alpine/Dockerfile
+++ b/library/jetty/template/eclipse-temurin/9.4/jdk11-alpine/Dockerfile
@@ -1,0 +1,84 @@
+# DO NOT EDIT. Edit baseDockerfile-alpine and use update.sh
+FROM lcr.loongnix.cn/library/eclipse-temurin:11-jdk-alpine
+
+ENV JETTY_VERSION 9.4.58.v20250814
+ENV JETTY_HOME /usr/local/jetty
+ENV JETTY_BASE /var/lib/jetty
+ENV TMPDIR /tmp/jetty
+ENV PATH $JETTY_HOME/bin:$PATH
+ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
+
+# GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)
+ENV JETTY_GPG_KEYS \
+	# Jan Bartel      <janb@mortbay.com>
+	AED5EE6C45D0FE8D5D1B164F27DED4BF6216DB8F \
+	# Jesse McConnell <jesse.mcconnell@gmail.com>
+	2A684B57436A81FA8706B53C61C3351A438A3B7D \
+	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
+	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
+	# Joakim Erdfelt  <joakime@apache.org>
+	B59B67FD7904984367F931800818D9D68FB67BAC \
+	# Joakim Erdfelt  <joakim@erdfelt.com>
+	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
+	# Simone Bordet   <simone.bordet@gmail.com>
+	8B096546B1A8F02656B15D3B1677D141BCF3584D \
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
+
+RUN set -xe ; \
+	mkdir -p $TMPDIR ; \
+	#
+	# Install utils needed to verify keys
+	apk add --no-cache gnupg curl ; \
+	#
+	# fetch GPG keys
+	export GNUPGHOME=/jetty-keys ; \
+	mkdir -p "$GNUPGHOME" ; \
+	for key in $JETTY_GPG_KEYS; do \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
+	done ; \
+	#
+	# Fetch jetty release into JETTY_HOME
+	mkdir -p "$JETTY_HOME" ; \
+	cd $JETTY_HOME ; \
+	curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz ; \
+	curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc ; \
+	#
+	# Verify GPG signatures
+	gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz ; \
+	#
+	# Unpack jetty
+	tar -xvf jetty.tar.gz --strip-components=1 ; \
+	sed -i '/jetty-logging/d' etc/jetty.conf ; \
+	#
+	# Create and configure the JETTY_HOME directory
+	mkdir -p "$JETTY_BASE" ; \
+	cd $JETTY_BASE ; \
+	case "$JETTY_VERSION" in \
+		"12."*) START_MODULES="server,http,ext,resources" ;; \
+		*) START_MODULES="server,http,deploy,ext,resources,jsp,jstl,websocket" ;; \
+	esac ; \
+	java -jar "$JETTY_HOME/start.jar" --create-startd \
+		--add-to-start="$START_MODULES" ; \
+	addgroup -S jetty && adduser -h $JETTY_BASE -S jetty -G jetty; \
+	chown -R jetty:jetty "$JETTY_HOME" "$JETTY_BASE" "$TMPDIR" ; \
+	#
+	# Cleanup
+	rm -rf /tmp/hsperfdata_root ; \
+	rm -fr $JETTY_HOME/jetty.tar.gz* ; \
+	gpgconf --kill all ; \
+	rm -fr /jetty-keys $GNUPGHOME ; \
+	rm -rf /tmp/hsperfdata_root ; \
+	#
+	# Basic smoke test
+	java -jar "$JETTY_HOME/start.jar" --list-config ;
+
+WORKDIR $JETTY_BASE
+COPY docker-entrypoint.sh generate-jetty-start.sh /
+
+USER jetty
+EXPOSE 8080
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/library/jetty/template/eclipse-temurin/9.4/jdk11-alpine/docker-entrypoint.sh
+++ b/library/jetty/template/eclipse-temurin/9.4/jdk11-alpine/docker-entrypoint.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = jetty.sh ]; then
+	if ! command -v bash >/dev/null 2>&1 ; then
+		cat >&2 <<- 'EOWARN'
+			********************************************************************
+			ERROR: bash not found. Use of jetty.sh requires bash.
+			********************************************************************
+		EOWARN
+		exit 1
+	fi
+	cat >&2 <<- 'EOWARN'
+		********************************************************************
+		WARNING: Use of jetty.sh from this image is deprecated and may
+			 be removed at some point in the future.
+
+			 See the documentation for guidance on extending this image:
+			 https://github.com/docker-library/docs/tree/master/jetty
+		********************************************************************
+	EOWARN
+fi
+
+if ! command -v -- "$1" >/dev/null 2>&1 ; then
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
+
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
+
+case "$JAVA_OPTIONS" in
+	*-Djava.io.tmpdir=*) ;;
+	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+esac
+
+if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-module* |\
+			--add-to-start* |\
+			--create-files |\
+			--create-start-ini |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--show-module* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			--write-module-graph* |\
+			-v )\
+			# It is a terminating command, so exec directly
+			JAVA="$1"
+			shift
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+		esac
+	done
+
+	if [ $(whoami) != "jetty" ]; then
+		cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: User is $(whoami)
+			         The user should be (re)set to 'jetty' in the Dockerfile
+			********************************************************************
+		EOWARN
+	fi
+
+	if [ -f $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+			cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the $JETTY_START files was generated.
+			         To avoid regeneration delays at start, either delete
+			         the $JETTY_START file or re-run /generate-jetty-start.sh
+			         from a Dockerfile.
+			********************************************************************
+			EOWARN
+			/generate-jetty-start.sh "$@"
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+	else
+		/generate-jetty-start.sh "$@"
+	fi
+
+	## The generate-jetty-start script always starts the jetty.start file with exec, so this command will exec Jetty.
+  ## We need to do this because the file may have quoted arguments which cannot be read into a variable.
+  . $JETTY_START
+fi
+
+if [ "${1##*/}" = java -a -n "$JAVA_OPTIONS" ] ; then
+	JAVA="$1"
+	shift
+	set -- "$JAVA" $JAVA_OPTIONS "$@"
+fi
+
+exec "$@"

--- a/library/jetty/template/eclipse-temurin/9.4/jdk11-alpine/generate-jetty-start.sh
+++ b/library/jetty/template/eclipse-temurin/9.4/jdk11-alpine/generate-jetty-start.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
+DRY_RUN=$(echo "$DRY_RUN" \
+	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
+	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
+
+# If jetty.start doesn't have content then the dry-run failed.
+if ! [ -s $JETTY_START ]; then
+	echo "jetty dry run failed:"
+	echo "$DRY_RUN" | awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1'
+	exit 1
+fi

--- a/library/jetty/template/eclipse-temurin/9.4/jdk11/Dockerfile
+++ b/library/jetty/template/eclipse-temurin/9.4/jdk11/Dockerfile
@@ -1,0 +1,100 @@
+# DO NOT EDIT. Edit baseDockerfile-slim and use update.sh
+FROM lcr.loongnix.cn/library/eclipse-temurin:11-jdk
+
+ENV JETTY_VERSION 9.4.58.v20250814
+ENV JETTY_HOME /usr/local/jetty
+ENV JETTY_BASE /var/lib/jetty
+ENV TMPDIR /tmp/jetty
+ENV PATH $JETTY_HOME/bin:$PATH
+ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
+
+# GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)
+ENV JETTY_GPG_KEYS \
+	# Jan Bartel      <janb@mortbay.com>
+	AED5EE6C45D0FE8D5D1B164F27DED4BF6216DB8F \
+	# Jesse McConnell <jesse.mcconnell@gmail.com>
+	2A684B57436A81FA8706B53C61C3351A438A3B7D \
+	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
+	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
+	# Joakim Erdfelt  <joakime@apache.org>
+	B59B67FD7904984367F931800818D9D68FB67BAC \
+	# Joakim Erdfelt  <joakim@erdfelt.com>
+	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
+	# Simone Bordet   <simone.bordet@gmail.com>
+	8B096546B1A8F02656B15D3B1677D141BCF3584D \
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
+
+RUN set -xe ; \
+	# Save initial installation state
+	export savedAptMark="$(apt-mark showmanual)" ; \
+	#
+	mkdir -p $TMPDIR ; \
+	#
+	# Install utils needed to verify keys
+	apt-get update ; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+		p11-kit \
+		gnupg2 \
+		curl \
+		; \
+	#
+	# fetch GPG keys
+	export GNUPGHOME=/jetty-keys ; \
+	mkdir -p "$GNUPGHOME" ; \
+	for key in $JETTY_GPG_KEYS; do \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
+	done ; \
+	#
+	# Fetch jetty release into JETTY_HOME
+	mkdir -p "$JETTY_HOME" ; \
+	cd $JETTY_HOME ; \
+	curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz ; \
+	curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc ; \
+	#
+	# Verify GPG signatures
+	gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz ; \
+	#
+	# Unpack jetty
+	tar -xvf jetty.tar.gz --strip-components=1 ; \
+	sed -i '/jetty-logging/d' etc/jetty.conf ; \
+	#
+	# Create and configure the JETTY_HOME directory
+	mkdir -p "$JETTY_BASE" ; \
+	cd $JETTY_BASE ; \
+	case "$JETTY_VERSION" in \
+		"12."*) START_MODULES="server,http,ext,resources" ;; \
+		*) START_MODULES="server,http,deploy,ext,resources,jsp,jstl,websocket" ;; \
+	esac ; \
+	java -jar "$JETTY_HOME/start.jar" --create-startd \
+		--add-to-start="$START_MODULES" ; \
+	groupadd -r jetty && useradd -r -g jetty jetty ; \
+	chown -R jetty:jetty "$JETTY_HOME" "$JETTY_BASE" "$TMPDIR" ; \
+	usermod -d $JETTY_BASE jetty ; \
+	gpgconf --kill all ; \
+	#
+	# Cleanup any apt
+	apt-mark auto '.*' > /dev/null ; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false ; \
+	rm -rf /var/lib/apt/lists/* ; \
+	#
+	# Cleanup
+	rm -rf /tmp/hsperfdata_root ; \
+	rm -fr $JETTY_HOME/jetty.tar.gz* ; \
+	rm -fr /jetty-keys $GNUPGHOME ; \
+	rm -rf /tmp/hsperfdata_root ; \
+	#
+	# Basic smoke test
+	java -jar "$JETTY_HOME/start.jar" --list-config ;
+
+WORKDIR $JETTY_BASE
+COPY docker-entrypoint.sh generate-jetty-start.sh /
+
+USER jetty
+EXPOSE 8080
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/library/jetty/template/eclipse-temurin/9.4/jdk11/docker-entrypoint.sh
+++ b/library/jetty/template/eclipse-temurin/9.4/jdk11/docker-entrypoint.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = jetty.sh ]; then
+	if ! command -v bash >/dev/null 2>&1 ; then
+		cat >&2 <<- 'EOWARN'
+			********************************************************************
+			ERROR: bash not found. Use of jetty.sh requires bash.
+			********************************************************************
+		EOWARN
+		exit 1
+	fi
+	cat >&2 <<- 'EOWARN'
+		********************************************************************
+		WARNING: Use of jetty.sh from this image is deprecated and may
+			 be removed at some point in the future.
+
+			 See the documentation for guidance on extending this image:
+			 https://github.com/docker-library/docs/tree/master/jetty
+		********************************************************************
+	EOWARN
+fi
+
+if ! command -v -- "$1" >/dev/null 2>&1 ; then
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
+
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
+
+case "$JAVA_OPTIONS" in
+	*-Djava.io.tmpdir=*) ;;
+	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+esac
+
+if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-module* |\
+			--add-to-start* |\
+			--create-files |\
+			--create-start-ini |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--show-module* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			--write-module-graph* |\
+			-v )\
+			# It is a terminating command, so exec directly
+			JAVA="$1"
+			shift
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+		esac
+	done
+
+	if [ $(whoami) != "jetty" ]; then
+		cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: User is $(whoami)
+			         The user should be (re)set to 'jetty' in the Dockerfile
+			********************************************************************
+		EOWARN
+	fi
+
+	if [ -f $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+			cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the $JETTY_START files was generated.
+			         To avoid regeneration delays at start, either delete
+			         the $JETTY_START file or re-run /generate-jetty-start.sh
+			         from a Dockerfile.
+			********************************************************************
+			EOWARN
+			/generate-jetty-start.sh "$@"
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+	else
+		/generate-jetty-start.sh "$@"
+	fi
+
+	## The generate-jetty-start script always starts the jetty.start file with exec, so this command will exec Jetty.
+  ## We need to do this because the file may have quoted arguments which cannot be read into a variable.
+  . $JETTY_START
+fi
+
+if [ "${1##*/}" = java -a -n "$JAVA_OPTIONS" ] ; then
+	JAVA="$1"
+	shift
+	set -- "$JAVA" $JAVA_OPTIONS "$@"
+fi
+
+exec "$@"

--- a/library/jetty/template/eclipse-temurin/9.4/jdk11/generate-jetty-start.sh
+++ b/library/jetty/template/eclipse-temurin/9.4/jdk11/generate-jetty-start.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
+DRY_RUN=$(echo "$DRY_RUN" \
+	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
+	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
+
+# If jetty.start doesn't have content then the dry-run failed.
+if ! [ -s $JETTY_START ]; then
+	echo "jetty dry run failed:"
+	echo "$DRY_RUN" | awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1'
+	exit 1
+fi

--- a/library/jetty/template/eclipse-temurin/9.4/jre11-alpine/Dockerfile
+++ b/library/jetty/template/eclipse-temurin/9.4/jre11-alpine/Dockerfile
@@ -1,0 +1,84 @@
+# DO NOT EDIT. Edit baseDockerfile-alpine and use update.sh
+FROM lcr.loongnix.cn/library/eclipse-temurin:11-jre-alpine
+
+ENV JETTY_VERSION 9.4.58.v20250814
+ENV JETTY_HOME /usr/local/jetty
+ENV JETTY_BASE /var/lib/jetty
+ENV TMPDIR /tmp/jetty
+ENV PATH $JETTY_HOME/bin:$PATH
+ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
+
+# GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)
+ENV JETTY_GPG_KEYS \
+	# Jan Bartel      <janb@mortbay.com>
+	AED5EE6C45D0FE8D5D1B164F27DED4BF6216DB8F \
+	# Jesse McConnell <jesse.mcconnell@gmail.com>
+	2A684B57436A81FA8706B53C61C3351A438A3B7D \
+	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
+	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
+	# Joakim Erdfelt  <joakime@apache.org>
+	B59B67FD7904984367F931800818D9D68FB67BAC \
+	# Joakim Erdfelt  <joakim@erdfelt.com>
+	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
+	# Simone Bordet   <simone.bordet@gmail.com>
+	8B096546B1A8F02656B15D3B1677D141BCF3584D \
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
+
+RUN set -xe ; \
+	mkdir -p $TMPDIR ; \
+	#
+	# Install utils needed to verify keys
+	apk add --no-cache gnupg curl ; \
+	#
+	# fetch GPG keys
+	export GNUPGHOME=/jetty-keys ; \
+	mkdir -p "$GNUPGHOME" ; \
+	for key in $JETTY_GPG_KEYS; do \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
+	done ; \
+	#
+	# Fetch jetty release into JETTY_HOME
+	mkdir -p "$JETTY_HOME" ; \
+	cd $JETTY_HOME ; \
+	curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz ; \
+	curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc ; \
+	#
+	# Verify GPG signatures
+	gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz ; \
+	#
+	# Unpack jetty
+	tar -xvf jetty.tar.gz --strip-components=1 ; \
+	sed -i '/jetty-logging/d' etc/jetty.conf ; \
+	#
+	# Create and configure the JETTY_HOME directory
+	mkdir -p "$JETTY_BASE" ; \
+	cd $JETTY_BASE ; \
+	case "$JETTY_VERSION" in \
+		"12."*) START_MODULES="server,http,ext,resources" ;; \
+		*) START_MODULES="server,http,deploy,ext,resources,jsp,jstl,websocket" ;; \
+	esac ; \
+	java -jar "$JETTY_HOME/start.jar" --create-startd \
+		--add-to-start="$START_MODULES" ; \
+	addgroup -S jetty && adduser -h $JETTY_BASE -S jetty -G jetty; \
+	chown -R jetty:jetty "$JETTY_HOME" "$JETTY_BASE" "$TMPDIR" ; \
+	#
+	# Cleanup
+	rm -rf /tmp/hsperfdata_root ; \
+	rm -fr $JETTY_HOME/jetty.tar.gz* ; \
+	gpgconf --kill all ; \
+	rm -fr /jetty-keys $GNUPGHOME ; \
+	rm -rf /tmp/hsperfdata_root ; \
+	#
+	# Basic smoke test
+	java -jar "$JETTY_HOME/start.jar" --list-config ;
+
+WORKDIR $JETTY_BASE
+COPY docker-entrypoint.sh generate-jetty-start.sh /
+
+USER jetty
+EXPOSE 8080
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/library/jetty/template/eclipse-temurin/9.4/jre11-alpine/docker-entrypoint.sh
+++ b/library/jetty/template/eclipse-temurin/9.4/jre11-alpine/docker-entrypoint.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = jetty.sh ]; then
+	if ! command -v bash >/dev/null 2>&1 ; then
+		cat >&2 <<- 'EOWARN'
+			********************************************************************
+			ERROR: bash not found. Use of jetty.sh requires bash.
+			********************************************************************
+		EOWARN
+		exit 1
+	fi
+	cat >&2 <<- 'EOWARN'
+		********************************************************************
+		WARNING: Use of jetty.sh from this image is deprecated and may
+			 be removed at some point in the future.
+
+			 See the documentation for guidance on extending this image:
+			 https://github.com/docker-library/docs/tree/master/jetty
+		********************************************************************
+	EOWARN
+fi
+
+if ! command -v -- "$1" >/dev/null 2>&1 ; then
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
+
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
+
+case "$JAVA_OPTIONS" in
+	*-Djava.io.tmpdir=*) ;;
+	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+esac
+
+if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-module* |\
+			--add-to-start* |\
+			--create-files |\
+			--create-start-ini |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--show-module* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			--write-module-graph* |\
+			-v )\
+			# It is a terminating command, so exec directly
+			JAVA="$1"
+			shift
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+		esac
+	done
+
+	if [ $(whoami) != "jetty" ]; then
+		cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: User is $(whoami)
+			         The user should be (re)set to 'jetty' in the Dockerfile
+			********************************************************************
+		EOWARN
+	fi
+
+	if [ -f $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+			cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the $JETTY_START files was generated.
+			         To avoid regeneration delays at start, either delete
+			         the $JETTY_START file or re-run /generate-jetty-start.sh
+			         from a Dockerfile.
+			********************************************************************
+			EOWARN
+			/generate-jetty-start.sh "$@"
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+	else
+		/generate-jetty-start.sh "$@"
+	fi
+
+	## The generate-jetty-start script always starts the jetty.start file with exec, so this command will exec Jetty.
+  ## We need to do this because the file may have quoted arguments which cannot be read into a variable.
+  . $JETTY_START
+fi
+
+if [ "${1##*/}" = java -a -n "$JAVA_OPTIONS" ] ; then
+	JAVA="$1"
+	shift
+	set -- "$JAVA" $JAVA_OPTIONS "$@"
+fi
+
+exec "$@"

--- a/library/jetty/template/eclipse-temurin/9.4/jre11-alpine/generate-jetty-start.sh
+++ b/library/jetty/template/eclipse-temurin/9.4/jre11-alpine/generate-jetty-start.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
+DRY_RUN=$(echo "$DRY_RUN" \
+	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
+	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
+
+# If jetty.start doesn't have content then the dry-run failed.
+if ! [ -s $JETTY_START ]; then
+	echo "jetty dry run failed:"
+	echo "$DRY_RUN" | awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1'
+	exit 1
+fi

--- a/library/jetty/template/eclipse-temurin/9.4/jre11/Dockerfile
+++ b/library/jetty/template/eclipse-temurin/9.4/jre11/Dockerfile
@@ -1,0 +1,100 @@
+# DO NOT EDIT. Edit baseDockerfile-slim and use update.sh
+FROM lcr.loongnix.cn/library/eclipse-temurin:11-jre
+
+ENV JETTY_VERSION 9.4.58.v20250814
+ENV JETTY_HOME /usr/local/jetty
+ENV JETTY_BASE /var/lib/jetty
+ENV TMPDIR /tmp/jetty
+ENV PATH $JETTY_HOME/bin:$PATH
+ENV JETTY_TGZ_URL https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
+
+# GPG Keys are personal keys of Jetty committers (see https://github.com/eclipse/jetty.project/blob/0607c0e66e44b9c12a62b85551da3a0edce0281e/KEYS.txt)
+ENV JETTY_GPG_KEYS \
+	# Jan Bartel      <janb@mortbay.com>
+	AED5EE6C45D0FE8D5D1B164F27DED4BF6216DB8F \
+	# Jesse McConnell <jesse.mcconnell@gmail.com>
+	2A684B57436A81FA8706B53C61C3351A438A3B7D \
+	# Joakim Erdfelt  <joakim.erdfelt@gmail.com>
+	5989BAF76217B843D66BE55B2D0E1FB8FE4B68B4 \
+	# Joakim Erdfelt  <joakime@apache.org>
+	B59B67FD7904984367F931800818D9D68FB67BAC \
+	# Joakim Erdfelt  <joakim@erdfelt.com>
+	BFBB21C246D7776836287A48A04E0C74ABB35FEA \
+	# Simone Bordet   <simone.bordet@gmail.com>
+	8B096546B1A8F02656B15D3B1677D141BCF3584D \
+	# Olivier Lamy    <olamy@apache.org>
+	F254B35617DC255D9344BCFA873A8E86B4372146 \
+	# Ludovic Orban   <lorban@bitronix.be>
+	E22488CC94F63E3FC928536C4241C08270D999C3
+
+RUN set -xe ; \
+	# Save initial installation state
+	export savedAptMark="$(apt-mark showmanual)" ; \
+	#
+	mkdir -p $TMPDIR ; \
+	#
+	# Install utils needed to verify keys
+	apt-get update ; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+		p11-kit \
+		gnupg2 \
+		curl \
+		; \
+	#
+	# fetch GPG keys
+	export GNUPGHOME=/jetty-keys ; \
+	mkdir -p "$GNUPGHOME" ; \
+	for key in $JETTY_GPG_KEYS; do \
+		gpg --batch --keyserver "hkps://keyserver.ubuntu.com" --recv-keys "$key"; \
+	done ; \
+	#
+	# Fetch jetty release into JETTY_HOME
+	mkdir -p "$JETTY_HOME" ; \
+	cd $JETTY_HOME ; \
+	curl -SL "$JETTY_TGZ_URL" -o jetty.tar.gz ; \
+	curl -SL "$JETTY_TGZ_URL.asc" -o jetty.tar.gz.asc ; \
+	#
+	# Verify GPG signatures
+	gpg --batch --verify jetty.tar.gz.asc jetty.tar.gz ; \
+	#
+	# Unpack jetty
+	tar -xvf jetty.tar.gz --strip-components=1 ; \
+	sed -i '/jetty-logging/d' etc/jetty.conf ; \
+	#
+	# Create and configure the JETTY_HOME directory
+	mkdir -p "$JETTY_BASE" ; \
+	cd $JETTY_BASE ; \
+	case "$JETTY_VERSION" in \
+		"12."*) START_MODULES="server,http,ext,resources" ;; \
+		*) START_MODULES="server,http,deploy,ext,resources,jsp,jstl,websocket" ;; \
+	esac ; \
+	java -jar "$JETTY_HOME/start.jar" --create-startd \
+		--add-to-start="$START_MODULES" ; \
+	groupadd -r jetty && useradd -r -g jetty jetty ; \
+	chown -R jetty:jetty "$JETTY_HOME" "$JETTY_BASE" "$TMPDIR" ; \
+	usermod -d $JETTY_BASE jetty ; \
+	gpgconf --kill all ; \
+	#
+	# Cleanup any apt
+	apt-mark auto '.*' > /dev/null ; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null ; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false ; \
+	rm -rf /var/lib/apt/lists/* ; \
+	#
+	# Cleanup
+	rm -rf /tmp/hsperfdata_root ; \
+	rm -fr $JETTY_HOME/jetty.tar.gz* ; \
+	rm -fr /jetty-keys $GNUPGHOME ; \
+	rm -rf /tmp/hsperfdata_root ; \
+	#
+	# Basic smoke test
+	java -jar "$JETTY_HOME/start.jar" --list-config ;
+
+WORKDIR $JETTY_BASE
+COPY docker-entrypoint.sh generate-jetty-start.sh /
+
+USER jetty
+EXPOSE 8080
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["java","-jar","/usr/local/jetty/start.jar"]

--- a/library/jetty/template/eclipse-temurin/9.4/jre11/docker-entrypoint.sh
+++ b/library/jetty/template/eclipse-temurin/9.4/jre11/docker-entrypoint.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = jetty.sh ]; then
+	if ! command -v bash >/dev/null 2>&1 ; then
+		cat >&2 <<- 'EOWARN'
+			********************************************************************
+			ERROR: bash not found. Use of jetty.sh requires bash.
+			********************************************************************
+		EOWARN
+		exit 1
+	fi
+	cat >&2 <<- 'EOWARN'
+		********************************************************************
+		WARNING: Use of jetty.sh from this image is deprecated and may
+			 be removed at some point in the future.
+
+			 See the documentation for guidance on extending this image:
+			 https://github.com/docker-library/docs/tree/master/jetty
+		********************************************************************
+	EOWARN
+fi
+
+if ! command -v -- "$1" >/dev/null 2>&1 ; then
+	set -- java -jar "$JETTY_HOME/start.jar" "$@"
+fi
+
+: ${TMPDIR:=/tmp/jetty}
+[ -d "$TMPDIR" ] || mkdir -p $TMPDIR 2>/dev/null
+
+: ${JETTY_START:=$JETTY_BASE/jetty.start}
+
+case "$JAVA_OPTIONS" in
+	*-Djava.io.tmpdir=*) ;;
+	*) JAVA_OPTIONS="-Djava.io.tmpdir=$TMPDIR $JAVA_OPTIONS" ;;
+esac
+
+if expr "$*" : 'java .*/start\.jar.*$' >/dev/null ; then
+	# this is a command to run jetty
+
+	# check if it is a terminating command
+	for A in "$@" ; do
+		case $A in
+			--add-module* |\
+			--add-to-start* |\
+			--create-files |\
+			--create-start-ini |\
+			--create-startd |\
+			--download |\
+			--dry-run |\
+			--exec-print |\
+			--help |\
+			--info |\
+			--list-all-modules |\
+			--list-classpath |\
+			--list-config |\
+			--list-modules* |\
+			--show-module* |\
+			--stop |\
+			--update-ini |\
+			--version |\
+			--write-module-graph* |\
+			-v )\
+			# It is a terminating command, so exec directly
+			JAVA="$1"
+			shift
+			# The $START_OPTIONS is the JVM options for the JVM which will do the --dry-run.
+			# The $JAVA_OPTIONS contains the JVM options used in the output of the --dry-run command.
+			eval "exec $JAVA $START_OPTIONS \"\$@\" $JAVA_OPTIONS $JETTY_PROPERTIES"
+		esac
+	done
+
+	if [ $(whoami) != "jetty" ]; then
+		cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: User is $(whoami)
+			         The user should be (re)set to 'jetty' in the Dockerfile
+			********************************************************************
+		EOWARN
+	fi
+
+	if [ -f $JETTY_START ] ; then
+
+		# Search for the Jetty Version comment in the jetty.start file.
+		JETTY_START_VERSION="$(
+			grep -m1 '^# JETTY_VERSION:' "$JETTY_START" 2>/dev/null \
+				| sed 's/^# JETTY_VERSION: //'
+		)"
+
+		# If the jetty.start file was generated with a different Jetty version we need to regenerate jetty.start.
+		if [ "$JETTY_START_VERSION" != "$JETTY_VERSION" ]; then
+			echo "$(date +'%Y-%m-%d %H:%M:%S'):INFO: Jetty version mismatch ($JETTY_START_VERSION -> $JETTY_VERSION), regenerating jetty.start" >&2
+			/generate-jetty-start.sh "$@"
+
+		# If the start.d directory has been modified we need to regenerate jetty.start.
+		elif [ $JETTY_BASE/start.d -nt $JETTY_START ] ; then
+			cat >&2 <<- EOWARN
+			********************************************************************
+			WARNING: The $JETTY_BASE/start.d directory has been modified since
+			         the $JETTY_START files was generated.
+			         To avoid regeneration delays at start, either delete
+			         the $JETTY_START file or re-run /generate-jetty-start.sh
+			         from a Dockerfile.
+			********************************************************************
+			EOWARN
+			/generate-jetty-start.sh "$@"
+		fi
+		echo $(date +'%Y-%m-%d %H:%M:%S.000'):INFO:docker-entrypoint:jetty start from $JETTY_START
+	else
+		/generate-jetty-start.sh "$@"
+	fi
+
+	## The generate-jetty-start script always starts the jetty.start file with exec, so this command will exec Jetty.
+  ## We need to do this because the file may have quoted arguments which cannot be read into a variable.
+  . $JETTY_START
+fi
+
+if [ "${1##*/}" = java -a -n "$JAVA_OPTIONS" ] ; then
+	JAVA="$1"
+	shift
+	set -- "$JAVA" $JAVA_OPTIONS "$@"
+fi
+
+exec "$@"

--- a/library/jetty/template/eclipse-temurin/9.4/jre11/generate-jetty-start.sh
+++ b/library/jetty/template/eclipse-temurin/9.4/jre11/generate-jetty-start.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ -z "$JETTY_START" ] ; then
+	JETTY_START=$JETTY_BASE/jetty.start
+fi
+rm -f $JETTY_START
+
+DRY_RUN=$(/docker-entrypoint.sh "$@" --dry-run | tee /dev/stderr)
+DRY_RUN=$(echo "$DRY_RUN" \
+	| egrep '[^ ]*java .*org\.eclipse\.jetty\.xml\.XmlConfiguration ' \
+	| sed -e 's/ -Djava.io.tmpdir=[^ ]*//g' -e 's/\\$//')
+echo "# JETTY_VERSION: $JETTY_VERSION" > "$JETTY_START"
+echo "exec $DRY_RUN" >> "$JETTY_START"
+
+# If jetty.start doesn't have content then the dry-run failed.
+if ! [ -s $JETTY_START ]; then
+	echo "jetty dry run failed:"
+	echo "$DRY_RUN" | awk '/\\$/ { printf "%s", substr($0, 1, length($0)-1); next } 1'
+	exit 1
+fi


### PR DESCRIPTION
- Add JDK 11 and JRE 11 variants for Jetty 9.4 and 10 (Jetty 12 requires Java 17+)
- Implement dynamic Java version adaptation based on major version
- Generate full tag sets matching upstream style:
  - Both with and without -eclipse-temurin suffix
  - Generic tags (without Java version) for latest JDK 25
  - Short aliases (9-*) for Jetty 9.4 versions
- Remove manual variant list in favor of runtime generation