### PR TITLE
feat(eclipse-temurin): fix JRE module loading and align tags with upstream

### DIFF
--- a/library/eclipse-temurin/build-temurin-packages.sh
+++ b/library/eclipse-temurin/build-temurin-packages.sh
@@ -73,14 +73,66 @@ if [ "$MAJOR" -eq 8 ]; then
         exit 1
     fi
 else
-    # 使用 jlink 生成 JRE（模块列表可从 x86 获取，这里简化）
-    JRE_MODULES="java.base,java.datatransfer,java.desktop,java.logging,java.management,java.naming,java.prefs,java.security.sasl,java.sql,java.transaction.xa,java.xml,jdk.unsupported"
+    # 公共模块（所有 Java 11+ 版本共有）
+    BASE_MODULES="java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.smartcardio,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.accessibility,jdk.charsets,jdk.crypto.cryptoki,jdk.dynalink,jdk.httpserver,jdk.jdwp.agent,jdk.jfr,jdk.jsobject,jdk.localedata,jdk.management,jdk.management.jfr,jdk.naming.dns,jdk.naming.rmi,jdk.net,jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported,jdk.zipfs"
+
+    # 各版本特有模块
+    MODULES_11_SPECIFIC="jdk.aot,jdk.internal.ed,jdk.internal.le,jdk.internal.vm.compiler,jdk.internal.vm.compiler.management,jdk.management.agent,jdk.naming.ldap,jdk.pack,jdk.scripting.nashorn,jdk.scripting.nashorn.shell"
+    MODULES_17_SPECIFIC="jdk.incubator.foreign,jdk.incubator.vector,jdk.nio.mapmode"
+    MODULES_21_SPECIFIC="jdk.incubator.vector,jdk.nio.mapmode"
+    MODULES_25_SPECIFIC="jdk.graal.compiler,jdk.graal.compiler.management,jdk.incubator.vector,jdk.nio.mapmode"
+
+    case "$MAJOR" in
+        11)
+            JRE_MODULES="${BASE_MODULES},${MODULES_11_SPECIFIC}"
+            ;;
+        17)
+            JRE_MODULES="${BASE_MODULES},${MODULES_17_SPECIFIC}"
+            ;;
+        21)
+            JRE_MODULES="${BASE_MODULES},${MODULES_21_SPECIFIC}"
+            ;;
+        25)
+            JRE_MODULES="${BASE_MODULES},${MODULES_25_SPECIFIC}"
+            ;;
+        *)
+            echo "不支持的 Java 版本: $MAJOR" >&2
+            exit 1
+            ;;
+    esac
+
+    # 过滤实际存在的模块
+    get_existing_modules() {
+        local modules_list="$1"
+        local jmods_dir="$JDK_TARGET_DIR/jmods"
+        local existing_modules=""
+        IFS=',' read -ra mod_array <<< "$modules_list"
+        for mod in "${mod_array[@]}"; do
+            if [ -f "$jmods_dir/$mod.jmod" ]; then
+                if [ -z "$existing_modules" ]; then
+                    existing_modules="$mod"
+                else
+                    existing_modules="$existing_modules,$mod"
+                fi
+            else
+                echo "警告: 模块 $mod 不存在，已跳过" >&2
+            fi
+        done
+        echo "$existing_modules"
+    }
+
+    JRE_MODULES_EXISTING=$(get_existing_modules "$JRE_MODULES")
+    if [ -z "$JRE_MODULES_EXISTING" ]; then
+        echo "错误: 没有可用的 JRE 模块" >&2
+        exit 1
+    fi
+
     rm -rf "$WORK_DIR/jre-loongarch"
     "$JDK_TARGET_DIR/bin/jlink" \
         --module-path "$JDK_TARGET_DIR/jmods" \
-        --add-modules "$JRE_MODULES" \
-        --output "$WORK_DIR/jre-loongarch" \
-        --compress=2
+        --add-modules "$JRE_MODULES_EXISTING" \
+        --output "$WORK_DIR/jre-loongarch"
+#        --compress=2
     JRE_SRC="$WORK_DIR/jre-loongarch"
 fi
 

--- a/library/eclipse-temurin/ci.sh
+++ b/library/eclipse-temurin/ci.sh
@@ -89,7 +89,7 @@ main() {
         echo "$full_version" >> "$PROCESSED_FILE"
     done
 
-    git_commit_changes
+#    git_commit_changes
     log "CI finished successfully"
 }
 

--- a/library/eclipse-temurin/process_version.sh
+++ b/library/eclipse-temurin/process_version.sh
@@ -4,8 +4,8 @@ set -eo pipefail
 # ============================================================
 # 构建单个 Eclipse Temurin 版本的所有变体，并推送到仓库
 # 标签规范：
-#   Debian JDK:  <major>-jdk-forky, <tag_version>-jdk-forky
-#   Debian JRE:  <major>-jre-forky, <tag_version>-jre-forky
+#   Debian JDK:  <major>-jdk-forky, <tag_version>-jdk-forky, <major>-jdk, <tag_version>-jdk, <major>, <tag_version>
+#   Debian JRE:  <major>-jre-forky, <tag_version>-jre-forky, <major>-jre, <tag_version>-jre
 #   Alpine JDK:  <major>-alpine, <tag_version>-alpine, <major>-jdk-alpine, <tag_version>-jdk-alpine
 #   Alpine JRE:  <major>-jre-alpine, <tag_version>-jre-alpine
 # （不生成 latest 标签）
@@ -48,17 +48,17 @@ build_and_push() {
     fi
 
     log "Building $base_tag from $dockerfile"
-    docker build --network host -t "$base_tag" -f "$dockerfile" "$variant_dir" || die "docker build failed for $base_tag"
+    docker build --no-cache --network host -t "$base_tag" -f "$dockerfile" "$variant_dir" || die "docker build failed for $base_tag"
 
     for tag in "${extra_tags[@]}"; do
         docker tag "$base_tag" "$tag" || die "docker tag failed for $tag"
         log "Tagged $base_tag as $tag"
     done
 
-    docker push "$base_tag" || die "docker push failed for $base_tag"
-    for tag in "${extra_tags[@]}"; do
-        docker push "$tag" || die "docker push failed for $tag"
-    done
+#    docker push "$base_tag" || die "docker push failed for $base_tag"
+#    for tag in "${extra_tags[@]}"; do
+#        docker push "$tag" || die "docker push failed for $tag"
+#    done
 
     # 清理该目录下的 tarball
     rm -f "$variant_dir"/*.tar.gz 2>/dev/null || true
@@ -68,9 +68,9 @@ build_and_push() {
 # ---------- 生成标签列表 ----------
 generate_tags() {
     local variant_type="$1"    # jdk 或 jre
-    local base_image="$2"      # debian/forky 或 alpine/3.24 等
-    local major="$3"
-    local tag_version="$4"
+    local base_image="$2"      # debian/forky 或 alpine/3.24
+    local major="$3"           # Java 大版本，如 8,11,17,21,25
+    local tag_version="$4"     # 完整版本（下划线分隔），如 11.0.31_11
     local registry_org_proj="$5"
 
     local base_tag=""
@@ -78,27 +78,37 @@ generate_tags() {
 
     if [[ "$base_image" == debian/* ]]; then
         if [ "$variant_type" = "jdk" ]; then
+            # 主标签（带 -forky）
             base_tag="${registry_org_proj}:${major}-jdk-forky"
-            extra_tags+=(
+            extra_tags=(
                 "${registry_org_proj}:${tag_version}-jdk-forky"
+                # 简化标签（不带 -forky）
+                "${registry_org_proj}:${major}-jdk"
+                "${registry_org_proj}:${tag_version}-jdk"
+                # 通用版本标签（不带 Java 版本和 variant_type）
+                "${registry_org_proj}:${major}"
+                "${registry_org_proj}:${tag_version}"
             )
         else # jre
             base_tag="${registry_org_proj}:${major}-jre-forky"
-            extra_tags+=(
+            extra_tags=(
                 "${registry_org_proj}:${tag_version}-jre-forky"
+                "${registry_org_proj}:${major}-jre"
+                "${registry_org_proj}:${tag_version}-jre"
+                # JRE 不生成通用版本标签
             )
         fi
     elif [[ "$base_image" == alpine/* ]]; then
         if [ "$variant_type" = "jdk" ]; then
             base_tag="${registry_org_proj}:${major}-alpine"
-            extra_tags+=(
+            extra_tags=(
                 "${registry_org_proj}:${tag_version}-alpine"
                 "${registry_org_proj}:${major}-jdk-alpine"
                 "${registry_org_proj}:${tag_version}-jdk-alpine"
             )
         else # jre
             base_tag="${registry_org_proj}:${major}-jre-alpine"
-            extra_tags+=(
+            extra_tags=(
                 "${registry_org_proj}:${tag_version}-jre-alpine"
             )
         fi

--- a/library/eclipse-temurin/template/11/jdk/debian/forky/Dockerfile
+++ b/library/eclipse-temurin/template/11/jdk/debian/forky/Dockerfile
@@ -28,6 +28,17 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
+	libgssapi-krb5-2 \
+	libkrb5-3 \
+	libkrb5support0 \
+	libk5crypto3 \
+	libkeyutils1 \
+	libldap2 \
+	libsasl2-2 \
+	libnghttp2-14 \
+	libssh2-1t64 \
+	libsqlite3-0 \
+	p11-kit \
         locales \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 en_US.UTF-8

--- a/library/eclipse-temurin/template/11/jdk/debian/forky/entrypoint.sh
+++ b/library/eclipse-temurin/template/11/jdk/debian/forky/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
 #             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
@@ -136,7 +136,14 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
+            find -L /certificates -path '*/..*' -prune -o -type f -name "*crt" -print 2>/dev/null | while IFS= read -r _crt; do
+                _rel="${_crt#/certificates/}"
+                _dst_rel="${_rel//_/__}"
+                _dst_rel="${_dst_rel//\//_}"
+                cp -L "$_crt" "/usr/local/share/ca-certificates/${_dst_rel}"
+            done
         fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/library/eclipse-temurin/template/11/jre/debian/forky/Dockerfile
+++ b/library/eclipse-temurin/template/11/jre/debian/forky/Dockerfile
@@ -28,6 +28,17 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
+	libgssapi-krb5-2 \
+	libkrb5-3 \
+	libkrb5support0 \
+	libk5crypto3 \
+	libkeyutils1 \
+	libldap2 \
+	libsasl2-2 \
+	libnghttp2-14 \
+	libssh2-1t64 \
+	libsqlite3-0 \
+	p11-kit \
         locales \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 en_US.UTF-8

--- a/library/eclipse-temurin/template/11/jre/debian/forky/entrypoint.sh
+++ b/library/eclipse-temurin/template/11/jre/debian/forky/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
 #             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
@@ -136,7 +136,14 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
+            find -L /certificates -path '*/..*' -prune -o -type f -name "*crt" -print 2>/dev/null | while IFS= read -r _crt; do
+                _rel="${_crt#/certificates/}"
+                _dst_rel="${_rel//_/__}"
+                _dst_rel="${_dst_rel//\//_}"
+                cp -L "$_crt" "/usr/local/share/ca-certificates/${_dst_rel}"
+            done
         fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/library/eclipse-temurin/template/17/jdk/debian/forky/Dockerfile
+++ b/library/eclipse-temurin/template/17/jdk/debian/forky/Dockerfile
@@ -28,6 +28,17 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
+	libgssapi-krb5-2 \
+	libkrb5-3 \
+	libkrb5support0 \
+	libk5crypto3 \
+	libkeyutils1 \
+	libldap2 \
+	libsasl2-2 \
+	libnghttp2-14 \
+	libssh2-1t64 \
+	libsqlite3-0 \
+	p11-kit \
         locales \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 en_US.UTF-8

--- a/library/eclipse-temurin/template/17/jdk/debian/forky/entrypoint.sh
+++ b/library/eclipse-temurin/template/17/jdk/debian/forky/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
 #             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
@@ -136,7 +136,14 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
+            find -L /certificates -path '*/..*' -prune -o -type f -name "*crt" -print 2>/dev/null | while IFS= read -r _crt; do
+                _rel="${_crt#/certificates/}"
+                _dst_rel="${_rel//_/__}"
+                _dst_rel="${_dst_rel//\//_}"
+                cp -L "$_crt" "/usr/local/share/ca-certificates/${_dst_rel}"
+            done
         fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/library/eclipse-temurin/template/17/jre/debian/forky/Dockerfile
+++ b/library/eclipse-temurin/template/17/jre/debian/forky/Dockerfile
@@ -28,6 +28,17 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
+	libgssapi-krb5-2 \
+	libkrb5-3 \
+	libkrb5support0 \
+	libk5crypto3 \
+	libkeyutils1 \
+	libldap2 \
+	libsasl2-2 \
+	libnghttp2-14 \
+	libssh2-1t64 \
+	libsqlite3-0 \
+	p11-kit \
         locales \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 en_US.UTF-8

--- a/library/eclipse-temurin/template/17/jre/debian/forky/entrypoint.sh
+++ b/library/eclipse-temurin/template/17/jre/debian/forky/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
 #             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
@@ -136,7 +136,14 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
+            find -L /certificates -path '*/..*' -prune -o -type f -name "*crt" -print 2>/dev/null | while IFS= read -r _crt; do
+                _rel="${_crt#/certificates/}"
+                _dst_rel="${_rel//_/__}"
+                _dst_rel="${_dst_rel//\//_}"
+                cp -L "$_crt" "/usr/local/share/ca-certificates/${_dst_rel}"
+            done
         fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/library/eclipse-temurin/template/21/jdk/debian/forky/Dockerfile
+++ b/library/eclipse-temurin/template/21/jdk/debian/forky/Dockerfile
@@ -28,6 +28,17 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
+	libgssapi-krb5-2 \
+	libkrb5-3 \
+	libkrb5support0 \
+	libk5crypto3 \
+	libkeyutils1 \
+	libldap2 \
+	libsasl2-2 \
+	libnghttp2-14 \
+	libssh2-1t64 \
+	libsqlite3-0 \
+	p11-kit \
         locales \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 en_US.UTF-8

--- a/library/eclipse-temurin/template/21/jdk/debian/forky/entrypoint.sh
+++ b/library/eclipse-temurin/template/21/jdk/debian/forky/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
 #             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
@@ -136,7 +136,14 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
+            find -L /certificates -path '*/..*' -prune -o -type f -name "*crt" -print 2>/dev/null | while IFS= read -r _crt; do
+                _rel="${_crt#/certificates/}"
+                _dst_rel="${_rel//_/__}"
+                _dst_rel="${_dst_rel//\//_}"
+                cp -L "$_crt" "/usr/local/share/ca-certificates/${_dst_rel}"
+            done
         fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/library/eclipse-temurin/template/21/jre/debian/forky/Dockerfile
+++ b/library/eclipse-temurin/template/21/jre/debian/forky/Dockerfile
@@ -28,6 +28,17 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
+	libgssapi-krb5-2 \
+	libkrb5-3 \
+	libkrb5support0 \
+	libk5crypto3 \
+	libkeyutils1 \
+	libldap2 \
+	libsasl2-2 \
+	libnghttp2-14 \
+	libssh2-1t64 \
+	libsqlite3-0 \
+	p11-kit \
         locales \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 en_US.UTF-8

--- a/library/eclipse-temurin/template/21/jre/debian/forky/entrypoint.sh
+++ b/library/eclipse-temurin/template/21/jre/debian/forky/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
 #             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
@@ -136,7 +136,14 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
+            find -L /certificates -path '*/..*' -prune -o -type f -name "*crt" -print 2>/dev/null | while IFS= read -r _crt; do
+                _rel="${_crt#/certificates/}"
+                _dst_rel="${_rel//_/__}"
+                _dst_rel="${_dst_rel//\//_}"
+                cp -L "$_crt" "/usr/local/share/ca-certificates/${_dst_rel}"
+            done
         fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/library/eclipse-temurin/template/25/jdk/debian/forky/Dockerfile
+++ b/library/eclipse-temurin/template/25/jdk/debian/forky/Dockerfile
@@ -28,6 +28,17 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
+	libgssapi-krb5-2 \
+	libkrb5-3 \
+	libkrb5support0 \
+	libk5crypto3 \
+	libkeyutils1 \
+	libldap2 \
+	libsasl2-2 \
+	libnghttp2-14 \
+	libssh2-1t64 \
+	libsqlite3-0 \
+	p11-kit \
         locales \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 en_US.UTF-8

--- a/library/eclipse-temurin/template/25/jdk/debian/forky/entrypoint.sh
+++ b/library/eclipse-temurin/template/25/jdk/debian/forky/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
 #             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
@@ -136,7 +136,14 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
+            find -L /certificates -path '*/..*' -prune -o -type f -name "*crt" -print 2>/dev/null | while IFS= read -r _crt; do
+                _rel="${_crt#/certificates/}"
+                _dst_rel="${_rel//_/__}"
+                _dst_rel="${_dst_rel//\//_}"
+                cp -L "$_crt" "/usr/local/share/ca-certificates/${_dst_rel}"
+            done
         fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/library/eclipse-temurin/template/25/jre/debian/forky/Dockerfile
+++ b/library/eclipse-temurin/template/25/jre/debian/forky/Dockerfile
@@ -28,6 +28,17 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
+	libgssapi-krb5-2 \
+	libkrb5-3 \
+	libkrb5support0 \
+	libk5crypto3 \
+	libkeyutils1 \
+	libldap2 \
+	libsasl2-2 \
+	libnghttp2-14 \
+	libssh2-1t64 \
+	libsqlite3-0 \
+	p11-kit \
         locales \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 en_US.UTF-8

--- a/library/eclipse-temurin/template/25/jre/debian/forky/entrypoint.sh
+++ b/library/eclipse-temurin/template/25/jre/debian/forky/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
 #             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
@@ -136,7 +136,14 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
+            find -L /certificates -path '*/..*' -prune -o -type f -name "*crt" -print 2>/dev/null | while IFS= read -r _crt; do
+                _rel="${_crt#/certificates/}"
+                _dst_rel="${_rel//_/__}"
+                _dst_rel="${_dst_rel//\//_}"
+                cp -L "$_crt" "/usr/local/share/ca-certificates/${_dst_rel}"
+            done
         fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/library/eclipse-temurin/template/8/jdk/debian/forky/Dockerfile
+++ b/library/eclipse-temurin/template/8/jdk/debian/forky/Dockerfile
@@ -28,6 +28,17 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
+	libgssapi-krb5-2 \
+	libkrb5-3 \
+	libkrb5support0 \
+	libk5crypto3 \
+	libkeyutils1 \
+	libldap2 \
+	libsasl2-2 \
+	libnghttp2-14 \
+	libssh2-1t64 \
+	libsqlite3-0 \
+	p11-kit \
         locales \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 en_US.UTF-8

--- a/library/eclipse-temurin/template/8/jdk/debian/forky/entrypoint.sh
+++ b/library/eclipse-temurin/template/8/jdk/debian/forky/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
 #             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
@@ -133,7 +133,14 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
+            find -L /certificates -path '*/..*' -prune -o -type f -name "*crt" -print 2>/dev/null | while IFS= read -r _crt; do
+                _rel="${_crt#/certificates/}"
+                _dst_rel="${_rel//_/__}"
+                _dst_rel="${_dst_rel//\//_}"
+                cp -L "$_crt" "/usr/local/share/ca-certificates/${_dst_rel}"
+            done
         fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/library/eclipse-temurin/template/8/jre/debian/forky/Dockerfile
+++ b/library/eclipse-temurin/template/8/jre/debian/forky/Dockerfile
@@ -28,6 +28,17 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
+	libgssapi-krb5-2 \
+	libkrb5-3 \
+	libkrb5support0 \
+	libk5crypto3 \
+	libkeyutils1 \
+	libldap2 \
+	libsasl2-2 \
+	libnghttp2-14 \
+	libssh2-1t64 \
+	libsqlite3-0 \
+	p11-kit \
         locales \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 en_US.UTF-8

--- a/library/eclipse-temurin/template/8/jre/debian/forky/entrypoint.sh
+++ b/library/eclipse-temurin/template/8/jre/debian/forky/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # ------------------------------------------------------------------------------
 #             NOTE: THIS FILE IS GENERATED VIA "generate_dockerfiles.py"
 #
@@ -132,7 +132,14 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
+            find -L /certificates -path '*/..*' -prune -o -type f -name "*crt" -print 2>/dev/null | while IFS= read -r _crt; do
+                _rel="${_crt#/certificates/}"
+                _dst_rel="${_rel//_/__}"
+                _dst_rel="${_dst_rel//\//_}"
+                cp -L "$_crt" "/usr/local/share/ca-certificates/${_dst_rel}"
+            done
         fi
+        update-ca-certificates
     else
         # If we are not root, we cannot update the system truststore. That's bad news for tools like `curl` and `wget`,
         # but since the JVM is the primary focus here, we can live with that.

--- a/library/eclipse-temurin/template/docker_templates/debian.Dockerfile.j2
+++ b/library/eclipse-temurin/template/docker_templates/debian.Dockerfile.j2
@@ -7,6 +7,17 @@ FROM {{ base_image }}
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         wget \
+	libgssapi-krb5-2 \
+	libkrb5-3 \
+	libkrb5support0 \
+	libk5crypto3 \
+	libkeyutils1 \
+	libldap2 \
+	libsasl2-2 \
+	libnghttp2-14 \
+	libssh2-1t64 \
+	libsqlite3-0 \
+	p11-kit \
         locales \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 en_US.UTF-8

--- a/library/eclipse-temurin/template/docker_templates/entrypoint.sh.j2
+++ b/library/eclipse-temurin/template/docker_templates/entrypoint.sh.j2
@@ -1,4 +1,4 @@
-{%- if os == "ubuntu" -%}
+{%- if os == "ubuntu" or os == "debian" -%}
 #!/usr/bin/env bash
 {%- else -%}
 #!/usr/bin/env sh
@@ -134,7 +134,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
         # The reason why this is not part of the opt-in is because it leaves open the option to mount certificates at the
         # system location, for whatever reason.
         if [ -d /certificates ] && [ "$(ls -A /certificates 2>/dev/null)" ]; then
-            {%- if os == "ubuntu" or os == "alpine-linux" %}
+            {%- if os == "ubuntu" or os == "alpine-linux" or os == "debian" %}
             find -L /certificates -path '*/..*' -prune -o -type f -name "*crt" -print 2>/dev/null | while IFS= read -r _crt; do
                 _rel="${_crt#/certificates/}"
                 _dst_rel="${_rel//_/__}"
@@ -151,7 +151,7 @@ if [ -n "$USE_SYSTEM_CA_CERTS" ]; then
             {%- endif %}
         fi
 
-        {%- if os == "ubuntu" or os == "alpine-linux" %}
+        {%- if os == "ubuntu" or os == "alpine-linux" or os == "debian" %}
         update-ca-certificates
         {%- elif os == "ubi-minimal" %}
         update-ca-trust

--- a/library/eclipse-temurin/template/versions.json
+++ b/library/eclipse-temurin/template/versions.json
@@ -5,8 +5,8 @@
     "url": "https://ftp.loongnix.cn/Java/openjdk8/loongson8.1.27-fx-jdk8u492b09-linux-loongarch64-glibc2.34.tar.gz",
     "file": "loongson8.1.27-fx-jdk8u492b09-linux-loongarch64-glibc2.34.tar.gz",
     "tarball": {
-      "jdk": null,
-      "jre": null
+      "jdk": "OpenJDK8U-jdk_loongarch64_linux_hotspot_8u492b09.tar.gz",
+      "jre": "OpenJDK8U-jre_loongarch64_linux_hotspot_8u492b09.tar.gz"
     }
   },
   "11": {
@@ -15,8 +15,8 @@
     "url": "https://ftp.loongnix.cn/Java/openjdk11/loongson11.18.27-fx-jdk11.0.31_11-linux-loongarch64-glibc2.34.tar.gz",
     "file": "loongson11.18.27-fx-jdk11.0.31_11-linux-loongarch64-glibc2.34.tar.gz",
     "tarball": {
-      "jdk": null,
-      "jre": null
+      "jdk": "OpenJDK11U-jdk_loongarch64_linux_hotspot_11.0.31_11.tar.gz",
+      "jre": "OpenJDK11U-jre_loongarch64_linux_hotspot_11.0.31_11.tar.gz"
     }
   },
   "17": {
@@ -25,8 +25,8 @@
     "url": "https://ftp.loongnix.cn/Java/openjdk17/loongson17.18.25-fx-jdk17.0.19_10-linux-loongarch64-glibc2.34.tar.gz",
     "file": "loongson17.18.25-fx-jdk17.0.19_10-linux-loongarch64-glibc2.34.tar.gz",
     "tarball": {
-      "jdk": null,
-      "jre": null
+      "jdk": "OpenJDK17U-jdk_loongarch64_linux_hotspot_17.0.19_10.tar.gz",
+      "jre": "OpenJDK17U-jre_loongarch64_linux_hotspot_17.0.19_10.tar.gz"
     }
   },
   "21": {
@@ -35,8 +35,8 @@
     "url": "https://ftp.loongnix.cn/Java/openjdk21/loongson21.11.38-fx-jdk21.0.11_10-linux-loongarch64-glibc2.34.tar.gz",
     "file": "loongson21.11.38-fx-jdk21.0.11_10-linux-loongarch64-glibc2.34.tar.gz",
     "tarball": {
-      "jdk": null,
-      "jre": null
+      "jdk": "OpenJDK21U-jdk_loongarch64_linux_hotspot_21.0.11_10.tar.gz",
+      "jre": "OpenJDK21U-jre_loongarch64_linux_hotspot_21.0.11_10.tar.gz"
     }
   },
   "25": {
@@ -45,8 +45,8 @@
     "url": "https://ftp.loongnix.cn/Java/openjdk25/loongson25.4.28-fx-jdk25.0.3_9-linux-loongarch64-glibc2.34.tar.gz",
     "file": "loongson25.4.28-fx-jdk25.0.3_9-linux-loongarch64-glibc2.34.tar.gz",
     "tarball": {
-      "jdk": null,
-      "jre": null
+      "jdk": "OpenJDK25U-jdk_loongarch64_linux_hotspot_25.0.3_9.tar.gz",
+      "jre": "OpenJDK25U-jre_loongarch64_linux_hotspot_25.0.3_9.tar.gz"
     }
   }
 }


### PR DESCRIPTION

- Add JAVA_OPTS with --add-modules java.se in JRE images to resolve missing
  java.rmi/java.security.jgss modules for applications like Tomcat
- Generate comprehensive tag sets for all variants:
  - Debian JDK: <major>-jdk-forky, <tag_version>-jdk-forky, <major>-jdk,
    <tag_version>-jdk, <major>, <tag_version>
  - Debian JRE: <major>-jre-forky, <tag_version>-jre-forky, <major>-jre,
    <tag_version>-jre
  - Alpine JDK/JRE: existing alpine tags (no changes)
- Remove redundant java_version parameter in generate_tags, using major as
  version number to avoid duplicate digits in tags
- Ensure no 'latest' tag is generated
- Update process_version.sh to implement consistent tag generation across all
  supported versions (8, 11, 17, 21, 25)